### PR TITLE
Macos framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set_target_properties(hikotest PROPERTIES RELWITHDEBINFO_POSTFIX "i")
 set_target_properties(hikotest PROPERTIES VERSION "${HIKOTEST_VERSION}")
 set_target_properties(hikotest PROPERTIES SOVERSION "${HIKOTEST_MAJOR_VERSION}")
 set_target_properties(hikotest PROPERTIES FRAMEWORK TRUE)
+set_target_properties(hikotest PROPERTIES FRAMEWORK_VERSION A)
 set_target_properties(hikotest PROPERTIES MACOSX_FRAMEWORK_IDENTIFIER "org.hikogui.hikotest")
 
 target_include_directories(hikotest PUBLIC
@@ -34,12 +35,14 @@ target_include_directories(hikotest PUBLIC
 set(INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATADIR}/hikotest/CMake")
 set(INSTALL_MODULEDIR "module")
 
-install(TARGETS hikotest EXPORT hikotest
+install(TARGETS hikotest
+    EXPORT hikotest
     FILE_SET hikotest_include_files
     RUNTIME
     ARCHIVE
     LIBRARY
     RESOURCE DESTINATION "${INSTALL_RESOURCEDIR}"
+    FRAMEWORK DESTINATION Library/Frameworks
 )
 
 install(

--- a/src/hikotest/hikotest.hpp
+++ b/src/hikotest/hikotest.hpp
@@ -150,6 +150,8 @@ template<typename T>
 
     // constexpr std::string class_name() [with T = foo<bar>; std::string_view = std::basic_string_view<char>]
     if (auto first = signature.find("::type_name() [with T = "); first != signature.npos) {
+        //                                     1         2
+        //                           0123456789012345678901234
         first += 24;
         auto const last = signature.find("; ", first);
         if (last == signature.npos) {
@@ -159,8 +161,23 @@ template<typename T>
         return type_name_strip(std::string{signature.substr(first, last - first)});
     }
 
+    // std::string test::type_name() [T = utf8_suite]
+    if (auto first = signature.find("::type_name() [T = "); first != signature.npos) {
+        //                                     1         
+        //                           01234567890123456789
+        first += 19;
+        auto const last = signature.find("]", first);
+        if (last == signature.npos) {
+            std::println(stderr, "{}({}): error: Could not parse type_name from '{}'", __FILE__, __LINE__, signature);
+            std::terminate();
+        }
+        return type_name_strip(std::string{signature.substr(first, last - first)});
+    }
+
     // __cdecltest::type_name(void)[T=foo<bar>]
     if (auto first = signature.find("::type_name(void) [T = "); first != signature.npos) {
+        //                                     1         2
+        //                           012345678901234567890123
         first += 23;
         auto const last = signature.find("]", first);
         if (last == signature.npos) {
@@ -172,6 +189,8 @@ template<typename T>
 
     // class std::basic_string<char,struct std::char_traits<char> > __cdecl test::type_name<struct foo<struct bar>>(void) noexcept
     if (auto first = signature.find("::type_name<"); first != signature.npos) {
+        //                                     1
+        //                           0123456789012
         first += 12;
         auto const last = signature.rfind(">(void)");
         return type_name_strip(std::string{signature.substr(first, last - first)});

--- a/src/hikotest/hikotest.hpp
+++ b/src/hikotest/hikotest.hpp
@@ -23,6 +23,7 @@
 #include <print>
 #include <expected>
 #include <optional>
+#include <exception>
 #include <stdexcept>
 
 namespace test {
@@ -111,7 +112,7 @@ namespace test {
 using hr_clock_type = std::chrono::high_resolution_clock;
 using hr_duration_type = std::chrono::duration<double>;
 using hr_time_point_type = std::chrono::time_point<hr_clock_type>;
-using utc_clock_type = std::chrono::utc_clock;
+using utc_clock_type = std::chrono::system_clock;
 using utc_time_point_type = utc_clock_type::time_point;
 
 /** Break the unit-test on failure.

--- a/src/hikotest/hikotest.hpp
+++ b/src/hikotest/hikotest.hpp
@@ -665,7 +665,7 @@ class require_error : public std::logic_error {
     using std::logic_error::logic_error;
 };
 
-TEST_FORCE_INLINE void require(char const* file, int line, std::expected<void, std::string> result)
+TEST_FORCE_INLINE inline void require(char const* file, int line, std::expected<void, std::string> result)
 {
     if (result) {
         return;


### PR DESCRIPTION
Fixes for using hikotest when building with apple-clang.

Changes:
- Build a Framework on MacOs
- std::chrome::utc_clock changed to std::chrome::system_clock
- Add function signature parser apple-clang
- Add <exception> header for std::terminate().
